### PR TITLE
Fix the "open space" flag

### DIFF
--- a/packages/less-ts/src/parser/stream.ts
+++ b/packages/less-ts/src/parser/stream.ts
@@ -13,7 +13,7 @@ export interface Parselet {
 export type Mark = [number, number, number, number];
 
 export const enum StreamFlags {
-  OPENSPACE
+  OPENSPACE = 1
 }
 
 const { min, max } = Math;


### PR DESCRIPTION
Enums start at `0` not `1` which messes up flag set/get using math.